### PR TITLE
Fix login with LinkedIn error

### DIFF
--- a/src/pages/login/Login.js
+++ b/src/pages/login/Login.js
@@ -180,10 +180,9 @@ class Login extends CoreEngine {
 
 
     requestProfile = () => {
+        Utilites.setCookie("regtype","login");
         var oauthUrl = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${Constants.LINK_REACT_APP_CLIENT_ID}&scope=r_liteprofile&state=123456&redirect_uri=${Constants.LINK_REACT_APP_REDICRECT_URL}`
-
         window.location = oauthUrl;
-
     };
 
     showInlineErrorMessage = error => this.setState({ error })


### PR DESCRIPTION
I was checking the business logic on the back-end and found out that everything is ok.
After checking the front-end code, I've realised that the regtype isn't updated when logging in with LinkedIn.
That was causing an API request as registration and not authentication.
So, I've added a line of code to update the regtype to "login" when authenticating the user.